### PR TITLE
Add support for search parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,47 +104,41 @@ The area marked on red is the app's `packageId`
 
 ### Advanced Options
 
-#### For Android
 
 ```javascript
-getAppstoreAppVersion(identifier, jquerySelector);
+getAppstoreAppVersion(identifier, options);
 ```
 
 **params:**
 
 - `identifier` is the app package id like `com.example.app`
 
-- `jquerySelector` is the dom element identifier (much like jquery selector) for playstore app page . Currently to get the appversion from the page we do load `https://play.google.com/store/apps/details?id=<app package id>` and parse `$('body > [itemprop="softwareVersion"]')` but you can optionally pass in a custom selector if you want. This is useful if dom structure of the app store page changes in the future.
+- `options` contains values which can affect the result obtained from the store
 
-**Example**
+    - `jquerySelector` [Android] is the dom element identifier (much like jquery selector) for playstore app page. Currently to get the appversion from the page we do load `https://play.google.com/store/apps/details?id=<app package id>` and parse `$('body > [itemprop="softwareVersion"]')` but you can optionally pass in a custom selector if you want. This is useful if dom structure of the app store page changes in the future.
 
-```javascript
-getAppstoreAppVersion('com.supercell.clashofclans', '[itemprop="softwareVersion"]')
-```
-
-#### For IOS
-
-```javascript
-getAppstoreAppVersion(identifier, typeOfId);
-```
-
-**params:**
-
-- `identifier` is the app package id like `com.example.app`
-
-- `typeOfId` (default is `id`) It can be either `id` or `bundleId`. If the `typeOfId` is `id` you need to pass `identifier` as appid and if `typeOfId` is `bundleId` you need to pass bundleIdentifier to `identifier`. It is basically, the query parameter for `https://itunes.apple.com/lookup?${typeOfId}=${identifier}`.
+    - `typeOfId` [iOS] (default is `id`) It can be either `id` or `bundleId`. If the `typeOfId` is `id` you need to pass `identifier` as appid and if `typeOfId` is `bundleId` you need to pass bundleIdentifier to `identifier`. It is basically, the query parameter for `https://itunes.apple.com/lookup?${typeOfId}=${identifier}`.
 Currently to get the ios version number from app store we hit the url `https://itunes.apple.com/lookup?id=<app id> ` by default.
 or we can also hit
 `https://itunes.apple.com/lookup?bundleId=<app bundle id>` if we pass typeOfId as `bundleId`.
 When we hit the above said urls we get json with all the info of the app.
 
+    - `country` [iOS] (default is `us`) The two-letter country code for the store you want to search. The search uses the default store front for the specified country.
+
 **Example**
 
 ```javascript
-getAppstoreAppVersion('529479190','id')
-or
-getAppstoreAppVersion('com.example.app','bundleId')
+const storeSpecificId = Platform.OS === 'ios'
+    ? '529479190'
+    : 'com.supercell.clashofclans'
+    
+getAppstoreAppVersion(storeSpecificId, {
+    jquerySelector: '[itemprop=\'softwareVersion\']',
+    typeOfId: 'id',
+    country: 'de'
+})
 ```
+
 
 ### License
 MIT

--- a/src/versionChecker.android.js
+++ b/src/versionChecker.android.js
@@ -1,7 +1,7 @@
 import {NativeModules} from 'react-native';
 import {get} from './fetcher';
 
-const getAppstoreAppVersion = (id, jquerySelector = '[itemprop=\'softwareVersion\']') => {
+const getAppstoreAppVersion = (id, { jquerySelector = '[itemprop=\'softwareVersion\']' }) => {
   const url = `https://play.google.com/store/apps/details?id=${id}`;
   return new Promise((resolve, reject) => {
     NativeModules.RNAppstoreVersionChecker.appVersionExtractor(url,jquerySelector,resolve, reject);

--- a/src/versionChecker.ios.js
+++ b/src/versionChecker.ios.js
@@ -1,8 +1,8 @@
 import result from 'lodash/result';
 import {get, parseJson} from './fetcher';
 
-const getAppstoreAppVersion = (identifier, typeOfId = 'id') => {
-  const url = `http://itunes.apple.com/lookup?${typeOfId}=${identifier}`;
+const getAppstoreAppVersion = (identifier, { typeOfId = 'id', country = 'us' }) => {
+  const url = `http://itunes.apple.com/lookup?${typeOfId}=${identifier}&country=${country}`;
   return get(url).then(parseJson).then((d) => {
     const version = result(d, 'data.results[0].version');
     if (!version) {


### PR DESCRIPTION
iTunes supports  a number of parameters one can use while searching within the app store: https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/

What I've encountered is the need to specify country in order to search for an app available in a specific country store. The following PR implements support for that. I've also updated the readme example to show a more cross-platform snippet.