### PR TITLE
Add support for React Native 0.47+

### DIFF
--- a/android/src/main/java/com/masteratul/RNAppstoreVersionCheckerPackage.java
+++ b/android/src/main/java/com/masteratul/RNAppstoreVersionCheckerPackage.java
@@ -17,11 +17,6 @@ public class RNAppstoreVersionCheckerPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }


### PR DESCRIPTION
On react native 0.47+ this package doesn't build due to [this breaking change](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8)