### PR TITLE
Cache breaking, better dependency management and optional country code

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-native": "*"
   },
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash.result": "^4.5.2"
   },
   "bugs": {
     "url": "https://github.com/master-atul/react-native-appstore-version-checker/issues"

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -12,7 +12,12 @@ export const get = (url) => {
   const config = {
     method: 'GET',
     credentials: 'include',
-    mode: 'no-cors'
+    mode: 'no-cors',
+    headers: {
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      'Pragma': 'no-cache',
+      'Expires': 0
+    }
   };
   return fetch(url, config).then((response) => {
     if (response.status === 200) {

--- a/src/versionChecker.ios.js
+++ b/src/versionChecker.ios.js
@@ -1,7 +1,7 @@
 import _result from 'lodash.result';
 import {get, parseJson} from './fetcher';
 
-const getAppstoreAppVersion = (identifier, options = { typeOfId: 'id', country: 'us' }) => {
+const getAppstoreAppVersion = (identifier, options = { typeOfId: 'id' }) => {
   const country = options.country ? `&country=${options.country}` : '';
   const url = `https://itunes.apple.com/lookup?${options.typeOfId}=${identifier}${country}`;
   return get(url).then(parseJson).then((d) => {

--- a/src/versionChecker.ios.js
+++ b/src/versionChecker.ios.js
@@ -1,10 +1,11 @@
-import result from 'lodash/result';
+import _result from 'lodash.result';
 import {get, parseJson} from './fetcher';
 
 const getAppstoreAppVersion = (identifier, options = { typeOfId: 'id', country: 'us' }) => {
-  const url = `https://itunes.apple.com/lookup?${options.typeOfId}=${identifier}&country=${options.country}`;
+  const country = options.country ? `&country=${options.country}` : '';
+  const url = `https://itunes.apple.com/lookup?${options.typeOfId}=${identifier}${country}`;
   return get(url).then(parseJson).then((d) => {
-    const version = result(d, 'data.results[0].version');
+    const version = _result(d, 'data.results[0].version');
     if (!version) {
       throw new Error('App not found!');
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-lodash@^4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+lodash.result@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.result/-/lodash.result-4.5.2.tgz#cb45b27fb914eaa8d8ee6f0ce7b2870b87cb70aa"


### PR DESCRIPTION
Nothing too major here.

I added some request headers to discourage any caching on the react-native side.

Also, as the only function used from `lodash` is result, I have added `lodash.result` as the only dependency instead.

There is one other minor edit which is removing default `country: us` config, as this is not needed.

Let me know if there is anything you think should be changed.