### PR TITLE
Added note about public version only

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ getAppstoreAppVersion(storeSpecificId, {
 });
 ```
 
+Quick note: it will get the public version from stores, that is, will not get alfa, beta or internal versions.
+
 ### Contributors
 
 - [Atul R](https://github.com/master-atul)


### PR DESCRIPTION
I faced it while testing here, that it just get the public version, even if the user is on an internal test group, alfa or beta, the package will grab ever the public version.

I think that information could be relevant for other devs.