### PR TITLE
feature: addGetAppstoreAppMetadata method that includes release date

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,26 +47,26 @@ Nothing to be done here ( its pure JS for IOS ;) )
 ## Usage
 
 ```javascript
-import { getAppstoreAppVersion } from "react-native-appstore-version-checker";
+import { getAppstoreAppMetadata } from "react-native-appstore-version-checker";
 
 or;
 
-var getAppstoreAppVersion = require("react-native-appstore-version-checker")
-  .getAppstoreAppVersion;
+var getAppstoreAppMetadata = require("react-native-appstore-version-checker")
+  .getAppstoreAppMetadata;
 
 //On Android u can do
-getAppstoreAppVersion("com.supercell.clashofclans") //put any apps packageId here
-  .then(appVersion => {
-    console.log("clashofclans android app version on playstore", appVersion);
+getAppstoreAppMetadata("com.supercell.clashofclans") //put any apps packageId here
+  .then(metadata => {
+    console.log("clashofclans android app version on playstore", metadata.version, "published on", metadata.currentVersionReleaseDate);
   })
   .catch(err => {
     console.log("error occurred", err);
   });
 
 //On IOS u can do
-getAppstoreAppVersion("529479190") //put any apps id here
+getAppstoreAppMetadata("529479190") //put any apps id here
   .then(appVersion => {
-    console.log("clash of clans ios app version on appstore", appVersion);
+    console.log("clashofclans android app version on appstore", metadata.version, "published on", metadata.currentVersionReleaseDate);
   })
   .catch(err => {
     console.log("error occurred", err);
@@ -108,7 +108,7 @@ The area marked on red is the app's `packageId`
 ### Advanced Options
 
 ```javascript
-getAppstoreAppVersion(identifier, options);
+getAppstoreAppMetadata(identifier, options);
 ```
 
 **params:**
@@ -117,7 +117,7 @@ getAppstoreAppVersion(identifier, options);
 
 - `options` contains values which can affect the result obtained from the store
 
-      - `jquerySelector` [Android] is the dom element identifier (much like jquery selector) for playstore app page. Currently to get the appversion from the page we do load `https://play.google.com/store/apps/details?id=<app package id>` and parse `$('body > [itemprop="softwareVersion"]')` but you can optionally pass in a custom selector if you want. This is useful if dom structure of the app store page changes in the future.
+      - `jquerySelectors` [Android] object with metadata property names to dom dom element identifiers (much like jquery selector) for playstore app page. Currently to get the appversion from the page we do load `https://play.google.com/store/apps/details?id=<app package id>` and parse `$('body > [itemprop="softwareVersion"]')` but you can optionally pass in a custom selector if you want. This is useful if dom structure of the app store page changes in the future.
 
       - `typeOfId` [iOS] (default is `id`) It can be either `id` or `bundleId`. If the `typeOfId` is `id` you need to pass `identifier` as appid and if `typeOfId` is `bundleId` you need to pass bundleIdentifier to `identifier`. It is basically, the query parameter for `https://itunes.apple.com/lookup?${typeOfId}=${identifier}`.
 
@@ -127,6 +127,26 @@ getAppstoreAppVersion(identifier, options);
   When we hit the above said urls we get json with all the info of the app.
 
       - `country` [iOS] (default is `us`) The two-letter country code for the store you want to search. The search uses the default store front for the specified country.
+
+```javascript
+const storeSpecificId =
+  Platform.OS === "ios" ? "529479190" : "com.supercell.clashofclans";
+
+getAppstoreAppMetadata(storeSpecificId, {
+  jquerySelectors: {
+    version: "[itemprop='softwareVersion']",
+  },
+  typeOfId: "id",
+  country: "de"
+});
+```
+
+```javascript
+getAppstoreAppVersion(identifier, options);
+```
+
+`getAppstoreAppVersion` has been maintained with previous versions for backwards compatibility. The only difference is that instead
+of `jquerySelectors`, the `options` objet only takes one selector for the app version and it's called `jquerySelector`.
 
 **Example**
 

--- a/android/src/main/java/com/masteratul/RNAppstoreVersionCheckerModule.java
+++ b/android/src/main/java/com/masteratul/RNAppstoreVersionCheckerModule.java
@@ -5,6 +5,9 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.Arguments;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -22,23 +25,40 @@ public class RNAppstoreVersionCheckerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void appVersionExtractor(
-            String url, String extractor,
+    public void extractMetadata(
+            String url, ReadableMap extractors,
             Callback successCallback,
             Callback errorCallback) {
         try {
             Document doc = Jsoup.connect(url).get();
-            String versionText;
-            if(extractor.equalsIgnoreCase("")){
-                versionText = doc.getElementsContainingOwnText("Current Version").parents().first().getAllElements().last().text();
-            }else{
-              versionText = doc.select(extractor).text();
-            }
+            WritableMap metadata = Arguments.createMap();
+
+            metadata.putString(
+                "version",
+                extractField(doc, "Current Version", "version", extractors)
+            );
+            metadata.putString(
+                "currentVersionReleaseDate",
+                extractField(doc, "Updated", "currentVersionReleaseDate", extractors)
+            );
+
             // https://stackoverflow.com/a/49924787/2881112
-            successCallback.invoke(versionText);
+            successCallback.invoke(metadata);
         } catch (Exception e) {
             errorCallback.invoke(e.getMessage());
         }
 
+    }
+
+    private String extractField(
+            Document doc,
+            String fieldLabel,
+            String extractorName,
+            ReadableMap extractors) {
+        if(extractors.hasKey(extractorName)) {
+            return doc.select(extractors.getString(extractorName)).text();
+        }
+
+        return doc.getElementsContainingOwnText(fieldLabel).parents().first().getAllElements().last().text();
     }
 }

--- a/src/versionChecker.android.js
+++ b/src/versionChecker.android.js
@@ -1,13 +1,34 @@
 import {NativeModules} from 'react-native';
-import {get} from './fetcher';
-const getAppstoreAppVersion = (id, options = { jquerySelector: "" }) => {
 
-  const url = `https://play.google.com/store/apps/details?id=${id}`;
-  return new Promise((resolve, reject) => {
-    NativeModules.RNAppstoreVersionChecker.appVersionExtractor(url,options.jquerySelector,resolve, reject);
-  });
+const extractMetadata = (url, jquerySelectors) => new Promise((resolve, reject) => {
+  NativeModules.RNAppstoreVersionChecker.extractMetadata(
+    url,
+    jquerySelectors,
+    resolve,
+    reject,
+  );
+});
+
+const getAppstoreAppMetadata = async (id, options = { jquerySelectors: {} }) => {
+  const language = options.language ? `&hl=${options.language}` : 'en';
+  const url = `https://play.google.com/store/apps/details?id=${id}&${language}`;
+  const { version, currentVersionReleaseDate } = await extractMetadata(url, options.jquerySelectors);
+  return {
+    version,
+    currentVersionReleaseDate: new Date(currentVersionReleaseDate),
+  };
+}
+
+const getAppstoreAppVersion = async (id, options = { jquerySelector: "" }) => {
+  const newOptions = {
+    jquerySelectors: { version: options.jquerySelector },
+    ...options,
+  };
+  const metadata = await getAppstoreAppMetadata(id, newOptions);
+  return metadata.version;
 };
 
 module.exports = {
-  getAppstoreAppVersion
+  getAppstoreAppVersion,
+  getAppstoreAppMetadata,
 };

--- a/src/versionChecker.ios.js
+++ b/src/versionChecker.ios.js
@@ -1,18 +1,29 @@
 import _result from 'lodash.result';
 import {get, parseJson} from './fetcher';
 
-const getAppstoreAppVersion = (identifier, options = { typeOfId: 'id' }) => {
+const getAppstoreAppMetadata = async (identifier, options = { typeOfId: 'id' }) => {
   const country = options.country ? `&country=${options.country}` : '';
   const url = `https://itunes.apple.com/lookup?${options.typeOfId}=${identifier}${country}`;
-  return get(url).then(parseJson).then((d) => {
-    const version = _result(d, 'data.results[0].version');
-    if (!version) {
-      throw new Error('App not found!');
-    }
-    return version;
-  });
+  const jsonData = await get(url);
+  const response = await parseJson(jsonData);
+
+  if (!response || !response.data || response.data.resultCount === 0 || response.data.results.length === 0) {
+    throw new Error('App not found!');
+  }
+  const version = _result(response, 'data.results[0].version');
+  const currentVersionReleaseDate = _result(response, 'data.results[0].currentVersionReleaseDate');
+  return {
+    version,
+    currentVersionReleaseDate: new Date(currentVersionReleaseDate),
+  }
+};
+
+const getAppstoreAppVersion = async (identifier, options) => {
+  const metadata = await getAppstoreAppMetadata(identifier, options);
+  return metadata.version;
 };
 
 module.exports = {
-  getAppstoreAppVersion
+  getAppstoreAppVersion,
+  getAppstoreAppMetadata,
 };


### PR DESCRIPTION
First of all, thanks for making `react-native-appstore-version-checker`, it is quite neat! 🙌 

In order to add an update prompt to an app after a new version had been published for more than X days I also needed to know the current app store version release date. This PR adds a `getAppstoreAppMetadata` method to the public API that returns an object with:

```js
{
    version,
    currentVersionReleaseDate,
}
```

The old `getAppstoreAppVersion` is preserved for backwards compatibility.

At the moment, we have forked the repo to use this new feature, but it would be amazing if this got merged into the upstream.

Cheers!